### PR TITLE
TKCoverflowCoverView image scaling problem

### DIFF
--- a/src/TapkuLibrary/TKCoverflowCoverView.m
+++ b/src/TapkuLibrary/TKCoverflowCoverView.m
@@ -76,7 +76,7 @@
 	
 	float w = image.size.width;
 	float h = image.size.height;
-	float factor = self.frame.size.width / (h>w?h:w);
+	float factor = self.bounds.size.width / (h>w?h:w);
 	h = factor * h;
 	w = factor * w;
 	float y = baseline - h > 0 ? baseline - h : 0;


### PR DESCRIPTION
Changed from self.frame to self.bounds, to avoid scaling problems when you change the cover image after the transform is already applied.
