### PR TITLE
Quick fix for monthly calendar heading timezone issue

### DIFF
--- a/src/TapkuLibrary/TKCalendarMonthView.m
+++ b/src/TapkuLibrary/TKCalendarMonthView.m
@@ -884,7 +884,10 @@
 		self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, self.bounds.size.width, self.tileBox.frame.size.height+self.tileBox.frame.origin.y);
 
 		self.shadow.frame = CGRectMake(0, self.frame.size.height-self.shadow.frame.size.height+21, self.shadow.frame.size.width, self.shadow.frame.size.height);
-		self.monthYear.text = [NSString stringWithFormat:@"%@ %@",[date monthString],[date yearString]];
+        
+        NSDate *localDate = [NSDate dateFromDateInformation:info];
+        self.monthYear.text = [NSString stringWithFormat:@"%@ %@",[localDate monthString],[localDate yearString]];
+
 		[currentTile selectDay:info.day];
 		
 		if([self.delegate respondsToSelector:@selector(calendarMonthView:monthDidChange:animated:)])


### PR DESCRIPTION
I was using the monthly calendar view's _selectDate_ method, passing in midnight on the first of the month, and I noticed that the heading was showing the previous month name ("June" instead of "July").  It looks like the date formatter expects local dates, but the month view was passing in GMT dates.

I just changed the month view to use local dates when calling _monthString_ and _yearString_.
