### PR TITLE
Fix crash in coverflow view caused by scrolling and rotating device.

### DIFF
--- a/src/TapkuLibrary/TKCoverflowView.m
+++ b/src/TapkuLibrary/TKCoverflowView.m
@@ -243,13 +243,21 @@
 	
 	int i = currentIndex-1;
 	if (i >= 0) 
-		for(;i > deck.location;i--) 
-			[self sendSubviewToBack:[coverViews objectAtIndex:i]];
+		for(;i > deck.location;i--)
+        {
+            UIView *v = [coverViews objectAtIndex:i];
+            if((NSObject*)v != [NSNull null])
+                [self sendSubviewToBack:v];
+        }
 	
 	i = currentIndex+1;
 	if(i<numberOfCovers-1) 
-		for(;i < deck.location+deck.length;i++) 
-			[self sendSubviewToBack:[coverViews objectAtIndex:i]];
+		for(;i < deck.location+deck.length;i++)
+        {
+            UIView *v = [coverViews objectAtIndex:i];
+            if((NSObject*)v != [NSNull null])
+                [self sendSubviewToBack:v];
+        }
 	
 	UIView *v = [coverViews objectAtIndex:currentIndex];
 	if((NSObject*)v != [NSNull null])


### PR DESCRIPTION
I found a crash inside adjustViewHeirarchy due to it not checking for NSNull and have made a fix. Please consider incorporating it into your main branch.

It appears the coverViews array has all its elements initially set to NSNull, and they are and lazily assigned to
TKCoverflowCoverView as required. The code in adjustViewHeirarchy was
not checking for NSNull when calling sendSubviewToBack causing a crash.
This bug was discovered by scrolling through the covers and rotating
the device. Fix is to check for NSNull before calling sendSubviewToBack.

I noticed there are various places in the code where a NSNull check is made on the elements of the coverview array. I'm not sure what is the root cause of this issue... possibly some kind of timing issue.
