### PR TITLE
Calendar Month Grid: Added support for multiple dots in the calendar

### DIFF
--- a/demo/iPhone/AppDelegate_iPhone.m
+++ b/demo/iPhone/AppDelegate_iPhone.m
@@ -33,7 +33,7 @@
 #import "RootViewController.h"
 
 @implementation AppDelegate_iPhone
-@synthesize root=_root,navigationController=_navigationController;
+@synthesize root=_root,navigationController=_navigationController,window=_window;
 
 
 #pragma mark -

--- a/demo/iPhone/DemoCalendarMonth.m
+++ b/demo/iPhone/DemoCalendarMonth.m
@@ -117,14 +117,18 @@
 		int r = arc4random();
 		if(r % 3==1){
 			[self.dataDictionary setObject:[NSArray arrayWithObjects:@"Item one",@"Item two",nil] forKey:d];
-			[self.dataArray addObject:[NSNumber numberWithBool:YES]];
+			[self.dataArray addObject:[NSNumber numberWithInt:2]]; //choose amount of dots
 			
 		}else if(r%4==1){
 			[self.dataDictionary setObject:[NSArray arrayWithObjects:@"Item one",nil] forKey:d];
-			[self.dataArray addObject:[NSNumber numberWithBool:YES]];
+			[self.dataArray addObject:[NSNumber numberWithInt:1]];
+			
+		}else if(r%5==1){
+			[self.dataDictionary setObject:[NSArray arrayWithObjects:@"Item one", @"Item two", @"Item three", @"Item four", nil] forKey:d];
+			[self.dataArray addObject:[NSNumber numberWithInt:4]];
 			
 		}else
-			[self.dataArray addObject:[NSNumber numberWithBool:NO]];
+			[self.dataArray addObject:[NSNumber numberWithInt:0]];
 		
 		
 		TKDateInformation info = [d dateInformationWithTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];

--- a/src/TapkuLibrary/TKCalendarMonthView.h
+++ b/src/TapkuLibrary/TKCalendarMonthView.h
@@ -124,7 +124,7 @@
  @param monthView The calendar month grid.
  @param startDate The first date shown by the calendar month grid.
  @param lastDate The last date shown by the calendar month grid.
- @return Returns an array of NSNumber objects corresponding the number of days specified in the start and last day parameters. Each NSNumber variable will give a BOOL value that will be used to display a dot under the day.
+ @return Returns an array of NSNumber objects corresponding the number of days specified in the start and last day parameters. Each NSNumber variable will give a INTEGER value that will be used to display 1 or more dots under the day.
  
  */
 - (NSArray*) calendarMonthView:(TKCalendarMonthView*)monthView marksFromDate:(NSDate*)startDate toDate:(NSDate*)lastDate;

--- a/src/TapkuLibrary/TKCalendarMonthView.m
+++ b/src/TapkuLibrary/TKCalendarMonthView.m
@@ -81,6 +81,7 @@
 
 #define dotFontSize 18.0
 #define dateFontSize 22.0
+#define numberOfMaxDots 6
 
 #pragma mark Accessibility Container methods
 - (BOOL) isAccessibilityElement{
@@ -277,7 +278,7 @@
 	
 	return CGRectMake(col*46, row*44+6, 47, 45);
 }
-- (void) drawTileInRect:(CGRect)r day:(int)day mark:(BOOL)mark font:(UIFont*)f1 font2:(UIFont*)f2{
+- (void) drawTileInRect:(CGRect)r day:(int)day mark:(int)mark font:(UIFont*)f1 font2:(UIFont*)f2{
 	
 	NSString *str = [NSString stringWithFormat:@"%d",day];
 	
@@ -292,7 +293,7 @@
 		r.size.height = 10;
 		r.origin.y += 18;
 		
-		[@"•" drawInRect: r
+		[[@"••••••" substringToIndex:MIN(MAX(mark, 0), numberOfMaxDots)] drawInRect: r
 				withFont: f2
 		   lineBreakMode: UILineBreakModeWordWrap 
 			   alignment: UITextAlignmentCenter];
@@ -327,9 +328,9 @@
 		for(int i = firstOfPrev;i<= lastOfPrev;i++){
 			r = [self rectForCellAtIndex:index];
 			if ([marks count] > 0)
-				[self drawTileInRect:r day:i mark:[[marks objectAtIndex:index] boolValue] font:font font2:font2];
+				[self drawTileInRect:r day:i mark:[[marks objectAtIndex:index] intValue] font:font font2:font2];
 			else
-				[self drawTileInRect:r day:i mark:NO font:font font2:font2];
+				[self drawTileInRect:r day:i mark:0 font:font font2:font2];
 			index++;
 		}
 	}
@@ -343,9 +344,9 @@
 		if(today == i) [[UIColor whiteColor] set];
 		
 		if ([marks count] > 0) 
-			[self drawTileInRect:r day:i mark:[[marks objectAtIndex:index] boolValue] font:font font2:font2];
+			[self drawTileInRect:r day:i mark:[[marks objectAtIndex:index] intValue] font:font font2:font2];
 		else
-			[self drawTileInRect:r day:i mark:NO font:font font2:font2];
+			[self drawTileInRect:r day:i mark:0 font:font font2:font2];
 		if(today == i) [color set];
 		index++;
 	}
@@ -355,9 +356,9 @@
 	while(index % 7 != 0){
 		r = [self rectForCellAtIndex:index] ;
 		if ([marks count] > 0) 
-			[self drawTileInRect:r day:i mark:[[marks objectAtIndex:index] boolValue] font:font font2:font2];
+			[self drawTileInRect:r day:i mark:[[marks objectAtIndex:index] intValue] font:font font2:font2];
 		else
-			[self drawTileInRect:r day:i mark:NO font:font font2:font2];
+			[self drawTileInRect:r day:i mark:0 font:font font2:font2];
 		i++;
 		index++;
 	}
@@ -398,18 +399,7 @@
 	[self addSubview:self.selectedImageView];
 	self.currentDay.text = [NSString stringWithFormat:@"%d",day];
 	
-	if ([marks count] > 0) {
-		
-		if([[marks objectAtIndex: row * 7 + column ] boolValue]){
-			[self.selectedImageView addSubview:self.dot];
-		}else{
-			[self.dot removeFromSuperview];
-		}
-		
-		
-	}else{
-		[self.dot removeFromSuperview];
-	}
+    self.dot.text = [@"••••••" substringToIndex:MIN(MAX([[marks objectAtIndex:(row*7+column)] intValue], 0), numberOfMaxDots)];
 	
 	if(column < 0){
 		column = 6;
@@ -494,14 +484,7 @@
 	[self addSubview:self.selectedImageView];
 	self.currentDay.text = [NSString stringWithFormat:@"%d",day];
 	
-	if ([marks count] > 0) {
-		if([[marks objectAtIndex: row * 7 + column] boolValue])
-			[self.selectedImageView addSubview:self.dot];
-		else
-			[self.dot removeFromSuperview];
-	}else{
-		[self.dot removeFromSuperview];
-	}
+    self.dot.text = [@"••••••" substringToIndex:MIN(MAX([[marks objectAtIndex:(row*7+column)] intValue], 0), numberOfMaxDots)];
 	
 
 	
@@ -559,7 +542,6 @@
 		r.origin.y += 29;
 		r.size.height -= 31;
 		_dot = [[UILabel alloc] initWithFrame:r];
-		_dot.text = @"•";
 		_dot.textColor = [UIColor whiteColor];
 		_dot.backgroundColor = [UIColor clearColor];
 		_dot.font = [UIFont boldSystemFontOfSize:dotFontSize];


### PR DESCRIPTION
Based on crm416 [solution](https://github.com/devinross/tapkulibrary/pull/199) 
- But only with dot's and no asterisks
- Even less changes.
- Users' old implementation's will still work because `[NSNumber numberWithBool:YES]`will be treated as an int of `1` showing 1 dot.
