### PR TITLE
Customization for TKAlertCenter alerts

### DIFF
--- a/src/TapkuLibrary/TKAlertCenter.h
+++ b/src/TapkuLibrary/TKAlertCenter.h
@@ -42,8 +42,9 @@
 	CGRect _alertFrame;
 }
 
-@property (strong) UIFont *alertTextFont;
 @property (strong) UIColor *alertBackgroundColor;
+@property (strong) UIFont *alertFont;
+@property (strong) UIColor *alertTextColor;
 
 /** Returns the process’s default notification center. 
  @return The current process’s default notification center, which is used for alert notifications.

--- a/src/TapkuLibrary/TKAlertCenter.m
+++ b/src/TapkuLibrary/TKAlertCenter.m
@@ -35,9 +35,13 @@
 #ifndef kTKAlertViewBackgroundColor
 #define kTKAlertViewBackgroundColor [UIColor colorWithWhite:0 alpha:0.8]
 #endif
-	 
-#ifndef kTKAlertViewTextFont	 
-#define kTKAlertViewTextFont [UIFont boldSystemFontOfSize:14]
+
+#ifndef kTKAlertViewFont
+#define kTKAlertViewFont [UIFont boldSystemFontOfSize:14]
+#endif
+
+#ifndef kTKAlertViewTextColor
+#define kTKAlertViewTextColor [UIColor whiteColor]
 #endif
 
 #pragma mark -
@@ -48,7 +52,8 @@
 }
 
 @property (strong) UIColor *alertBackgroundColor;
-@property (strong) UIFont *alertTextFont;
+@property (strong) UIFont *alertFont;
+@property (strong) UIColor *alertTextColor;
 
 - (id) init;
 - (void) setMessageText:(NSString*)str;
@@ -65,7 +70,8 @@
 	_messageRect = CGRectInset(self.bounds, 10, 10);
 	self.backgroundColor = [UIColor clearColor];
     self.alertBackgroundColor = kTKAlertViewBackgroundColor;
-    self.alertTextFont = kTKAlertViewTextFont;
+    self.alertFont = kTKAlertViewFont;
+    self.alertTextColor = kTKAlertViewTextColor;
 	return self;
 	
 }
@@ -95,9 +101,9 @@
 - (void) drawRect:(CGRect)rect{
 	[self.alertBackgroundColor set];
 	[self _drawRoundRectangleInRect:rect withRadius:10];
-	[[UIColor whiteColor] set];
+	[self.alertTextColor set];
 	[_text drawInRect:_messageRect
-			 withFont:self.alertTextFont
+			 withFont:self.alertFont
 		lineBreakMode:NSLineBreakByWordWrapping
 			alignment:NSTextAlignmentCenter];
 	
@@ -112,7 +118,7 @@
 #pragma mark Setter Methods
 - (void) adjust{
 	
-	CGSize s = [_text sizeWithFont:self.alertTextFont
+	CGSize s = [_text sizeWithFont:self.alertFont
 				 constrainedToSize:CGSizeMake(160,200)
 					 lineBreakMode:NSLineBreakByWordWrapping];
 	
@@ -173,14 +179,14 @@
 	return self;
 }
 
--(void)setAlertTextFont:(UIFont *)alertTextFont
+-(void)setAlertFont:(UIFont *)alertFont
 {
-    _alertView.alertTextFont = alertTextFont;
+    _alertView.alertFont = alertFont;
 }
 
-- (UIFont *)alertTextFont
+- (UIFont *)alertFont
 {
-    return _alertView.alertTextFont;
+    return _alertView.alertFont;
 }
 
 -(void)setAlertBackgroundColor:(UIColor *)alertBackgroundColor
@@ -191,6 +197,16 @@
 - (UIColor *)alertBackgroundColor
 {
     return _alertView.alertBackgroundColor;
+}
+
+-(void)setAlertTextColor:(UIColor *)alertTextColor
+{
+    _alertView.alertTextColor = alertTextColor;
+}
+
+- (UIColor *)alertTextColor
+{
+    return _alertView.alertTextColor;
 }
 
 #pragma mark Show Alert Message


### PR DESCRIPTION
AlertCenter is pretty cool, but you can't customize alert.

Instead of exposing alertView class. I've decided to add two methods (alertFont, alertTextColor, alertBackgroundColor) on AlertCenter itself.

Both method are proxy to alertCenter's alertView, and can be change at time any time (the alert is redraw each time it's shown).

``` Objective-C


- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
{
    [self.window makeKeyAndVisible];

/*
 Be aware that accessing defaultCenter before window is visible will capture an invalid frame.
 via _alertFrame = [UIApplication sharedApplication].keyWindow.bounds in [TKAlertCenter init]
*/
    [TKAlertCenter defaultCenter].alertTextFont = [UIFont boldSystemFontOfSize:19]; 
    [TKAlertCenter defaultCenter].alertTextFont = [UIFont boldSystemFontOfSize:19]; 
    [TKAlertCenter defaultCenter].alertBackgroundColor = [UIColor redColor];

    return YES;
}
```

I've also move default alertFont, alertTextColor and alertBackgroundColor to constants in top of TKAlertCenter.m.
