### PR TITLE
iOS 5 EventView label issue fixed

### DIFF
--- a/src/TapkuLibrary/TKCalendarDayEventView.m
+++ b/src/TapkuLibrary/TKCalendarDayEventView.m
@@ -126,7 +126,7 @@
 	
 	
 	self.titleLabel.frame = r;
-	[self.titleLabel sizeToFit];
+	if([[[UIDevice currentDevice] systemVersion] floatValue] >= 6) [self.titleLabel sizeToFit];
 	
 	hh = h > 200 ? (FONT_SIZE+2.0) * 2 : FONT_SIZE+2;
 	r = CGRectInset(self.bounds, 5, 5);
@@ -136,7 +136,7 @@
 
 	self.locationLabel.frame = r;
 	self.locationLabel.hidden = self.locationLabel.text.length > 0 ? NO : YES;
-	[self.locationLabel sizeToFit];
+	if([[[UIDevice currentDevice] systemVersion] floatValue] >= 6) [self.locationLabel sizeToFit];
 
 }
 


### PR DESCRIPTION
On iOS 5 the TKCalendarDayEventView's titleLabel and locationLabel text is going out of the event view if the string is too long.
Without sizeToFit everything is fine ion iOS 5

![ios5issue](https://f.cloud.github.com/assets/2952613/604474/4fee5e20-ccf6-11e2-8656-607b01a3848c.png)
