### PR TITLE
TKTextView honours editable property.

### DIFF
--- a/src/TapkuLibrary/TKTextViewCell.m
+++ b/src/TapkuLibrary/TKTextViewCell.m
@@ -40,6 +40,7 @@
 	_textView = [[TKTextView alloc] initWithFrame:CGRectZero];
 	_textView.font = [UIFont boldSystemFontOfSize:14.0];
 	_textView.backgroundColor = [UIColor clearColor];
+	_textView.editable = NO;
 	[self.contentView addSubview:_textView];
 	
 	return self;
@@ -54,6 +55,10 @@
 	_textView.frame = CGRectInset(self.contentView.bounds, 4, 4);
 }
 
+-(void)setEditing:(BOOL)editing animated:(BOOL)animated{
+	[super setEditing:editing animated:animated];
+	self.textView.editable = editing;
+}
 
 - (void) _colorText:(BOOL)active{
 	_textView.textColor = active ? [UIColor whiteColor] : [UIColor blackColor];


### PR DESCRIPTION
Hello,

Here's a small change that makes `TKTextViewCell` honour its editable property. If the cell (or the parent tableview) is editable, so is the textview. Otherwise, it's static (but still allows for text selection).
