### PR TITLE
Fixed a bug in the position of the month calendar in iOS 7.

### DIFF
--- a/src/TapkuLibrary/TKCalendarMonthViewController.m
+++ b/src/TapkuLibrary/TKCalendarMonthViewController.m
@@ -55,12 +55,14 @@
 	if(!(self = [super init])) return nil;
 	self.timeZone = timeZone;
 	self.sundayFirst = sundayFirst;
+    self.edgesForExtendedLayout = UIExtendedEdgeNone;
 	return self;
 }
 - (id) initWithCoder:(NSCoder *)decoder {
     if(!(self=[super initWithCoder:decoder])) return nil;
 	self.timeZone = [NSTimeZone defaultTimeZone];
 	self.sundayFirst = YES;
+    self.edgesForExtendedLayout = UIExtendedEdgeNone;
     return self;
 }
 


### PR DESCRIPTION
Just a correction to the position of the month calendar in iOS 7, because the view controller assumes fullscreen layout by default. I believe there are more components with this problem.
