### PR TITLE
support low event views that are squeezed due to collision

### DIFF
--- a/src/TapkuLibrary.xcodeproj/project.pbxproj
+++ b/src/TapkuLibrary.xcodeproj/project.pbxproj
@@ -868,7 +868,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -895,7 +894,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/src/TapkuLibrary/TKCalendarDayEventView.m
+++ b/src/TapkuLibrary/TKCalendarDayEventView.m
@@ -111,6 +111,14 @@
 	
 	if(h < 75){
 		self.titleLabel.frame = CGRectInset(self.bounds, 5, 5);
+		// if the entry is small enough, clamp label to 1 line and fit width to
+		// event view size
+		if (h <= 45) {
+		  self.titleLabel.numberOfLines = 1;
+		  [self.titleLabel sizeToFit];
+		  self.titleLabel.frame = CGRectIntersection(self.titleLabel.frame, CGRectInset(self.bounds, 5, 5));
+		}
+
 		CGFloat y = self.titleLabel.frame.size.height + self.titleLabel.frame.origin.y;
 		self.locationLabel.frame = CGRectMake(self.titleLabel.frame.origin.x, y, 0, 0);
 		self.locationLabel.hidden = YES;


### PR DESCRIPTION
Prior to this patch, small event views would have the label incorrectly positioned;

![screen shot 2013-11-28 at 12 20 26](https://f.cloud.github.com/assets/161259/1639392/3ec0d8bc-581f-11e3-96b0-04d8ee02c74b.png)

After the patch, low event views will clip line numbers to 2 and truncate label frame to intersect with event view frame

![screen shot 2013-11-28 at 12 20 56](https://f.cloud.github.com/assets/161259/1639396/58670ebc-581f-11e3-9be8-c90953ec5677.png)
