### PR TITLE
refactor setCancelled method

### DIFF
--- a/src/TapkuLibrary/TKHTTPRequest.m
+++ b/src/TapkuLibrary/TKHTTPRequest.m
@@ -453,7 +453,7 @@ static inline NSString * TKKeyPathFromOperationState(TKOperationState state) {
 
 - (void) setCancelled:(BOOL)cancelled {
     [self willChangeValueForKey:@"isCancelled"];
-    _cancelled = cancelled;
+    self.cancelled = cancelled;
     [self didChangeValueForKey:@"isCancelled"];
     
     if ([self isCancelled]) self.state = TKOperationStateFinished;


### PR DESCRIPTION
With Xcode 6, `_cancelled = cancelled` occurs an error.
Apple maybe deprecate this written pattern under ARC.